### PR TITLE
ENH: Add `notebook` to requirements files

### DIFF
--- a/requirements/requirements_lps_vs_ras_nb.txt
+++ b/requirements/requirements_lps_vs_ras_nb.txt
@@ -2,5 +2,6 @@ fury
 dipy
 matplotlib
 nibabel
+notebook
 numpy
 requests

--- a/requirements/requirements_tracking_spatial_mismatch_nb.txt
+++ b/requirements/requirements_tracking_spatial_mismatch_nb.txt
@@ -2,4 +2,5 @@ fury
 dipy
 matplotlib
 nibabel
+notebook
 numpy

--- a/requirements/requirements_trackvis_corner_vs_center_nb.txt
+++ b/requirements/requirements_trackvis_corner_vs_center_nb.txt
@@ -1,3 +1,4 @@
 fury
 nibabel>=3.0.0,<4.0.0
+notebook
 numpy>=1.23.0,<2.0.0


### PR DESCRIPTION
Add `notebook` to requirements files.

Fixes:
```
Run docker run --rm -v
 /home/runner/work/Standardization-Position-Paper/Standardization-Position-Paper:/work -w
 /work tractography_issues_image \
  docker run --rm -v
 /home/runner/work/Standardization-Position-Paper/Standardization-Position-Paper:/work -w
 /work tractography_issues_image \
    jupyter nbconvert
 --to notebook
 --execute notebooks/notebooks/trackvis_corner_vs_center.ipynb
 --output executed-notebooks/notebooks/trackvis_corner_vs_center.ipynb
  shell: /usr/bin/bash -e {0}
docker: Error response from daemon:
 failed to create task for container:
 failed to create shim task:
 OCI runtime create failed:
 runc create failed:
 unable to start container process:
 error during container init:
 exec: "jupyter": executable file not found in $PATH: unknown.
```

raised for example in:
https://github.com/jhlegarreta/Standardization-Position-Paper/actions/runs/14481202183/job/40618336802#step:4:7